### PR TITLE
Install epel-release to meet aws-cfn-bootstrap dependency

### DIFF
--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -4,13 +4,17 @@
 #
 # This script assumes standard AWS-hosted location for the
 # CLI ZIP-file. It may be overridden by passing a URI as
-# the lone argument to the script
+# the first argument to the script.
+#
+# For the second argument, provide the url to the epel-release
+# package, or it will default to one publicly available.
 #
 ############################################################
 SCRIPTROOT="$(dirname ${0})"
 CHROOT="${CHROOT:-/mnt/ec2-root}"
 BUNDLE="awscli-bundle.zip"
 ZIPSRC="${1:-https://s3.amazonaws.com/aws-cli}"
+EPELRELEASE="${2:-https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm}"
 AWSZIP="/tmp/${BUNDLE}"
 
 # Bail if bogus location for ZIP
@@ -48,4 +52,5 @@ rm -rf ${CHROOT}/root/awscli-bundle
 # Depending on RPMs dependencies, this may fail if a repo is
 # missing (e.g. EPEL). Will also fail if no RPMs are present
 # in the search directory.
+yum --installroot=${CHROOT} install -y ${EPELRELASE}
 yum --installroot=${CHROOT} install -y ${SCRIPTROOT}/AWSpkgs/*.noarch.rpm

--- a/README.dependencies
+++ b/README.dependencies
@@ -1,6 +1,7 @@
 The following RPMs must be present in order for the AMI-creation scripts to function:
 * coreutils
 * e2fsprogs
+* epel-release
 * gawk
 * grep
 * grub
@@ -12,6 +13,7 @@ The following RPMs must be present in order for the AMI-creation scripts to func
 * util-linux-ng
 * yum-utils
 With a @Core install, this should result in the following being installed:
+* epel-release
 * lvm2
   * lvm2-libs
   * device-mapper


### PR DESCRIPTION
The epel repo must be present both on the build host and in the
chroot environment. This patch updates both the build host dependencies
listed in the README, and the AWScliSetup.sh script that installs the
package to the chroot.

Defaulting to a url for EPELRELEASE was chosen for compatibility
across both CentOS and RHEL vendor repos, as the RHEL repos do not
include epel-release.

Fixes #33
