### PR TITLE
Make /sbin/fixfiles non-interactive

### DIFF
--- a/PreRelabel.sh
+++ b/PreRelabel.sh
@@ -38,5 +38,5 @@ fi
 
 # Relabel the chroot-env
 printf "Relabeling the chroot env... "
-chroot $CHROOT /sbin/fixfiles relabel && echo "Success!" || \
+chroot $CHROOT /sbin/fixfiles -f relabel && echo "Success!" || \
    fatal "Operation may have failed."


### PR DESCRIPTION
Using `/sbin/fixfiles -f` suppresses the interactive message about
cleaning /tmp.

Fixes #37
