### PR TITLE
Reinstall release RPMs to pickup dependencies

### DIFF
--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -5,9 +5,10 @@
 #####################################
 CHROOT="${CHROOT:-/mnt/ec2-root}"
 CONFROOT=`dirname $0`
-REPODIS="--disablerepo=* --enablerepo=chroot-*"
 
 function PrepChroot() {
+   local DISABLEREPOS="*media*,*epel*,C*-*"
+
    if [[ ! -e ${CHROOT}/etc/init.d ]]
    then
       ln -t ${CHROOT}/etc -s rc.d/init.d
@@ -18,6 +19,8 @@ function PrepChroot() {
       -qf /etc/yum.repos.d/* | sort -u)
    rpm --root ${CHROOT} --initdb
    rpm --root ${CHROOT} -ivh --nodeps /tmp/*.rpm
+   yum --enablerepo=* --disablerepo=${DISABLEREPOS} --installroot=${CHROOT} \
+      -y reinstall $(rpm --qf '%{name}\n' -qf /etc/yum.repos.d/* | sort -u)
 }
 
 PrepChroot

--- a/CleanChroot.sh
+++ b/CleanChroot.sh
@@ -9,7 +9,7 @@ CLOUDCFG="$CHROOT/etc/cloud/cloud.cfg"
 MAINTUSR="maintuser"
 
 # Get rid of stale RPM data
-chroot ${CHROOT} yum clean -y packages
+chroot ${CHROOT} yum clean --enablerepo=* -y packages
 chroot ${CHROOT} rm -rf /var/cache/yum
 chroot ${CHROOT} rm -rf /var/lib/yum
 


### PR DESCRIPTION
- The `rh-amazon-rhui-client` package manages the enabled repos for licensed RHEL EC2 instances, but it cannot run the script to enable the repos without installing the dependencies for the package.
- Since the fix for the problem involves enabling all repos during an install, this patch also enables all repos when cleaning out the packages in CleanChroot.sh.

Fixes #50
