### PR TITLE
Do not leave epel repos enabled in the CHROOT

### DIFF
--- a/CleanChroot.sh
+++ b/CleanChroot.sh
@@ -8,6 +8,9 @@ CONFROOT=`dirname $0`
 CLOUDCFG="$CHROOT/etc/cloud/cloud.cfg"
 MAINTUSR="maintuser"
 
+# Disable EPEL repos
+chroot ${CHROOT} yum-config-manager --disable "*epel*" > /dev/null
+
 # Get rid of stale RPM data
 chroot ${CHROOT} yum clean --enablerepo=* -y packages
 chroot ${CHROOT} rm -rf /var/cache/yum


### PR DESCRIPTION
Epel mirrors are notoriously unreliable. To avoid problems reaching
mirrors, disable the epel repos in the CHROOT so they will be
disabled by default in the resulting AMI.
