### PR TITLE
PR for Issues 69 & 70

### DIFF
--- a/GrowSetup.sh
+++ b/GrowSetup.sh
@@ -6,9 +6,10 @@
 SCRIPTROOT="$(dirname ${0})"
 CHROOT="${CHROOT:-/mnt/ec2-root}"
 GROWDIR="usr/share/dracut/modules.d/50growroot"
+EPELREPO="${1:-epel}"
 
 # Install the grow modules from EPEL
-yum --installroot=$CHROOT --enablerepo=epel install -y dracut-modules-growroot
+yum --installroot=$CHROOT --enablerepo="${EPELREPO}" install -y dracut-modules-growroot
 
 if [[ $? -ne 0 ]]
 then


### PR DESCRIPTION
Fixes #69
- Undo removal of bonusrepos feature

Fixes #70
- up to script user to specify a valid EPEL repo-name. Script will
  not validate (beyond barfing on its shoes if the repo-name is
  invalid or malformed).

Misc fixes
- Bin the "not owned" errors from the checking of /etc/yum.repos.d
