### PR TITLE
Avoids path pollution caused by aws tools

### DIFF
--- a/AWScliSetup.sh
+++ b/AWScliSetup.sh
@@ -54,7 +54,7 @@ fi
 cp -r /tmp/awscli-bundle ${CHROOT}/root
 
 # Install AWScli bundle into ${CHROOT}
-chroot ${CHROOT} /root/awscli-bundle/install -i /opt/aws -b /usr/bin/aws
+chroot ${CHROOT} /root/awscli-bundle/install -i /opt/aws/cli -b /usr/bin/aws
 
 # Verify AWScli functionality within ${CHROOT}
 chroot ${CHROOT} /usr/bin/aws --version


### PR DESCRIPTION
Installing the awscli-bundle.zip file to `/opt/aws` will install
an entire python environment to that location, including a number
of executables at `/opt/aws/bin`. The amitools and apitools RPMs
then also install to `/opt/aws` and include a profile.d script
that adds `/opt/aws/bin` to the PATH. This combination means the
executables provided by the awscli python environment end up in
the PATH.

This patch changes the install directory for awscli-bundle.zip to
`/opt/aws/cli`, which avoids polluting the PATH when also
installing the amitools and apitools packages.
