### PR TITLE
Loops over the REPORPMS array correctly

### DIFF
--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -51,7 +51,7 @@ function PrepChroot() {
    # if alt-repo defined, disable everything, then install alt-repos
    if [[ ! -z ${REPORPMS+xxx} ]]
    then
-      for RPM in ${REPORPMS}
+      for RPM in "${REPORPMS[@]}"
       do
          rpm --root ${CHROOT} -ivh --nodeps "${RPM}"
       done


### PR DESCRIPTION
When adding the ability to specify multiple REPORPMS, missed this
loop. Only the first repo rpm was being installed.
