### PR TITLE
Enables dns resolution in the chroot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ env:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 
-addons:
-  apt:
-    sources:
-      - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-      - shellcheck
-
 matrix:
   include:
     - env:

--- a/ChrootBuild.sh
+++ b/ChrootBuild.sh
@@ -32,6 +32,12 @@ function PrepChroot() {
       ln -t ${CHROOT}/etc -s rc.d/init.d
    fi
 
+   # Enable DNS resolution in the chroot
+   if [[ ! -e ${CHROOT}/etc/resolv.conf ]]
+   then
+      install -m 0644 /etc/resolv.conf "${CHROOT}/etc"
+   fi
+
    yumdownloader --destdir=/tmp $(rpm --qf '%{name}\n' -qf /etc/redhat-release)
    yumdownloader --destdir=/tmp "${REPORFILEPMS[@]}"
    rpm --root ${CHROOT} --initdb


### PR DESCRIPTION
#### Description:

- Enables DNS resolution from the chroot jail

#### Rationale:

- Package installs (`awscli-bundle.zip` in particular) sometimes require resolution to install successfully
